### PR TITLE
token menu is shown if saved token is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Ignore Gradle build output directory
 build
 bin
+
+# ignore intellij config
+.idea

--- a/DiminishingColoursBot/src/main/java/diminishingcoloursbot/Main.java
+++ b/DiminishingColoursBot/src/main/java/diminishingcoloursbot/Main.java
@@ -142,7 +142,7 @@ public class Main {
 
         loadSaves();
 
-        if (token == null) {
+        if (token == null || token.isEmpty()) {
             tokenMenu(null);
         } else
             start();


### PR DESCRIPTION
Previously if the saved token was a empty string the socket would fail to authenticate and the bot would not load making it impossible to change the token, after this change if the saved token is an empty string the token menu is brought up.